### PR TITLE
feat: registry mirrors override path

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,14 @@ Type: `map(list(string))`
 
 Default: `null`
 
+### <a name="input_registry_mirrors_override_path"></a> [registry\_mirrors\_override\_path](#input\_registry\_mirrors\_override\_path)
+
+Description: Override the registry mirrors path generation. Overrides detection of '/v2/' in the registry mirror urls.
+
+Type: `bool`
+
+Default: `null`
+
 ### <a name="input_tags"></a> [tags](#input\_tags)
 
 Description: List of tags for each node. (NG).

--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,8 @@ module "talos" {
   ip_addresses = each.value.ipv4_addresses
   vip_address  = var.vip_address
 
-  registry_mirrors = var.registry_mirrors
+  registry_mirrors               = var.registry_mirrors
+  registry_mirrors_override_path = var.registry_mirrors_override_path
 
   metrics_server = var.metrics_server
 

--- a/modules/talos/README.md
+++ b/modules/talos/README.md
@@ -175,6 +175,14 @@ Type: `map(list(string))`
 
 Default: `null`
 
+### <a name="input_registry_mirrors_override_path"></a> [registry\_mirrors\_override\_path](#input\_registry\_mirrors\_override\_path)
+
+Description: Override the registry mirrors path generation. Overrides detection of '/v2/' in the registry mirror urls.
+
+Type: `bool`
+
+Default: `null`
+
 ### <a name="input_vip_address"></a> [vip\_address](#input\_vip\_address)
 
 Description: Virtual IP address, only used for contarolplane nodes.

--- a/modules/talos/main.tf
+++ b/modules/talos/main.tf
@@ -1,10 +1,15 @@
 locals {
+  // This code checks if any of the registry mirrors endpoints contain the "/v2/"
+  // string. This is used to determine if the overridePath for the registry mirrors
+  // should be set to the registry_mirrors_override_path variable or to true.
+  mirrors_with_v2 = anytrue(flatten([for k, mirrors in var.registry_mirrors : [for mirror in mirrors : strcontains(mirror, "/v2/")]]))
   registry_mirrors = var.registry_mirrors == null ? "" : yamlencode({
     machine = {
       registries = {
         mirrors = {
           for k, v in var.registry_mirrors : k => {
-            endpoints = v
+            endpoints    = v
+            overridePath = var.registry_mirrors_override_path != null ? var.registry_mirrors_override_path : local.mirrors_with_v2
           }
         }
       }
@@ -30,10 +35,6 @@ locals {
       }
     }
   })
-  cilium = var.cilium && var.machine_type == "controlplane" ? templatefile("${path.module}/templates/cilium.yaml.tftpl", {
-    version     = var.cilium_version
-    cli_version = var.cilium_cli_version
-  }) : ""
   node_labels = var.node_labels != {} ? yamlencode({
     machine = {
       nodeLabels = var.node_labels
@@ -52,6 +53,11 @@ locals {
         }
       }
     }
+  }) : ""
+  // Cluster configuration items
+  cilium = var.cilium && var.machine_type == "controlplane" ? templatefile("${path.module}/templates/cilium.yaml.tftpl", {
+    version     = var.cilium_version
+    cli_version = var.cilium_cli_version
   }) : ""
   metrics_server = var.metrics_server && var.machine_type == "controlplane" && length(var.metrics_server_manifest_urls) > 0 ? yamlencode({
     cluster = {
@@ -76,12 +82,12 @@ data "talos_machine_configuration" "this" {
     local.installer_image,
     local.vip,
     local.registry_mirrors,
-    local.cilium,
     local.rotate_certs,
+    local.node_labels,
+    local.node_taints,
+    local.cilium,
     local.metrics_server,
     local.extra_manifests,
-    local.node_labels,
-    local.node_taints
   ])
 }
 
@@ -92,13 +98,9 @@ resource "talos_machine_configuration_apply" "this" {
   machine_configuration_input = data.talos_machine_configuration.this.machine_configuration
 
   node = var.ip_addresses[count.index]
-
-  # Bad things can happen if changes are not managed in a controled manner.
-  lifecycle {
-    ignore_changes = [machine_configuration_input]
-  }
 }
 
+// Bootstrap the first control plane node
 resource "talos_machine_bootstrap" "this" {
   count = var.machine_type == "controlplane" ? 1 : 0
 

--- a/modules/talos/templates/cilium.yaml.tftpl
+++ b/modules/talos/templates/cilium.yaml.tftpl
@@ -57,6 +57,9 @@ cluster:
                 - key: node-role.kubernetes.io/control-plane
                   operator: Exists
                   effect: PreferNoSchedule
+                - key: node.cilium.io/agent-not-ready
+                  operator: Exists
+                  effect: NoExecute
               affinity:
                 nodeAffinity:
                   requiredDuringSchedulingIgnoredDuringExecution:

--- a/modules/talos/variables.tf
+++ b/modules/talos/variables.tf
@@ -56,6 +56,12 @@ variable "registry_mirrors" {
   default     = null
 }
 
+variable "registry_mirrors_override_path" {
+  description = "Override the registry mirrors path generation. Overrides detection of '/v2/' in the registry mirror urls."
+  type        = bool
+  default     = null
+}
+
 variable "cilium" {
   description = "Install Cilium."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -88,6 +88,12 @@ variable "registry_mirrors" {
   default     = null
 }
 
+variable "registry_mirrors_override_path" {
+  description = "Override the registry mirrors path generation. Overrides detection of '/v2/' in the registry mirror urls."
+  type        = bool
+  default     = null
+}
+
 variable "pve_node_names" {
   description = "List of Proxmox node names to distribue the VM over. Placement is round-robin. (NG)."
   type        = list(string)


### PR DESCRIPTION
Harbor, maybe other registry mirrors, have v2 in the path before the mirror name element. 
This change allows setting talos override so talos doesn't add the v2. It also detects if v2 is already in the registry mirror and if so enabled override for those mirrors.